### PR TITLE
Fix #3 Travis selenium intermittent fails

### DIFF
--- a/test/integration.js
+++ b/test/integration.js
@@ -374,10 +374,13 @@ describe('hoodie.account', function () {
     // simulate an invalid session by changing the session id in localStorage
     // and reloading the page
     .executeAsync(function simulateUnauthenticatedState (done) {
-      var account = JSON.parse(window.localStorage.getItem('account'))
-      account.session.id = 'invalidsessionid'
-      window.localStorage.setItem('account', JSON.stringify(account))
-      window.setTimeout(done, 100)
+      function delayedCheck () {
+        var account = JSON.parse(window.localStorage.getItem('account'))
+        account.session.id = 'invalidsessionid'
+        window.localStorage.setItem('account', JSON.stringify(account))
+        done()
+      }
+      window.setTimeout(delayedCheck, 100)
     })
     .url('/')
     .execute(function (accountEventNames) {

--- a/test/integration.js
+++ b/test/integration.js
@@ -242,7 +242,7 @@ describe('hoodie.account', function () {
     .then(function (account) {
       expect(account.username).to.equal(newUsername)
       expect(account.id).to.match(/^\w+$/)
-      expect(Object.keys(account).sort()).to.deep.equal(['craetedAt', 'id', 'signedUpAt', 'username'])
+      expect(Object.keys(account).sort()).to.deep.equal(['createdAt', 'id', 'signedUpAt', 'username'])
     })
   })
 


### PR DESCRIPTION
This attempts to resolve the timing issues categorized by errors of [this type](https://travis-ci.org/hoodiehq/hoodie-account/builds/167970252) (but not [this type](https://travis-ci.org/hoodiehq/hoodie-account/builds/169432225), which seems to be resulting from a sauce labs connection issue) by introducing a delay before the value of the localStorage in the selenium-controlled client is retrieved and set.

I approached this by trying to recreate the conditions by calling sauce labs from my local machine, and then to fix it by retrying the `getItem` call after a delay. I had one instance where, within the client's executable context, the value of `account` had been retrieved without the `session` key, and then after a delay, the value of account retrieved then had the `session` key set.